### PR TITLE
chore: downgrade go mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/u-root/cpuid
 
-go 1.23.0
+go 1.22.0
+
+toolchain go1.22.6


### PR DESCRIPTION
To [match](https://github.com/u-root/u-root/blob/main/go.mod#L3) github.com/u-root/u-root, downgrade this package's go version.